### PR TITLE
[BACKLOG-4144] - VizAPI versions side-by-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dev-lib/
 test-lib/
 /documentation/spec.html
 !/package-res/resources/web/lib/
+.idea

--- a/package-res/resources/web/pentaho/visual/calendar/Visual.js
+++ b/package-res/resources/web/pentaho/visual/calendar/Visual.js
@@ -155,7 +155,7 @@ define([
               fade:    false,
               followMouse: true,
               corners: true,
-              arrow:   false,
+              arrowVisible: false,
               opacity: 1
             };
 

--- a/package-res/resources/web/pentaho/visual/funnel/Visual.js
+++ b/package-res/resources/web/pentaho/visual/funnel/Visual.js
@@ -110,7 +110,7 @@ define([
               fade:    false,
               followMouse: true,
               corners: true,
-              arrow:   false,
+              arrowVisible: false,
               opacity: 1
             };
 

--- a/package-res/resources/web/pentaho/visual/packedCircle/Visual.js
+++ b/package-res/resources/web/pentaho/visual/packedCircle/Visual.js
@@ -196,7 +196,7 @@ define([
               fade:    false,
               followMouse: true,
               corners: true,
-              arrow:   false,
+              arrowVisible: false,
               opacity: 1
             };
 

--- a/package-res/resources/web/pentaho/visual/parallelCoords/Visual.js
+++ b/package-res/resources/web/pentaho/visual/parallelCoords/Visual.js
@@ -155,7 +155,7 @@ define([
               fade:    false,
               followMouse: true,
               corners: true,
-              arrow:   false,
+              arrowVisible: false,
               opacity: 1
             };
 

--- a/package-res/resources/web/pentaho/visual/sunBurst/Visual.js
+++ b/package-res/resources/web/pentaho/visual/sunBurst/Visual.js
@@ -238,7 +238,7 @@ define([
               fade:    false,
               followMouse: true,
               corners: true,
-              arrow:   false,
+              arrowVisible: false,
               opacity: 1
             };
 

--- a/package-res/resources/web/pentaho/visual/treeMap/Visual.js
+++ b/package-res/resources/web/pentaho/visual/treeMap/Visual.js
@@ -149,7 +149,7 @@ define([
               fade:    false,
               followMouse: true,
               corners: true,
-              arrow:   false,
+              arrowVisible: false,
               opacity: 1
             };
 

--- a/package-res/resources/web/pentaho/visual/visualTypeHelper.js
+++ b/package-res/resources/web/pentaho/visual/visualTypeHelper.js
@@ -45,7 +45,7 @@ define([
 
             visualType.id = typeId;
             visualType.localTypeId = localTypeId;
-            visualType.name = Messages.getString(typeName);
+            visualType.name = 'X - ' + Messages.getString(typeName);
             visualType.factory = visualFactory;
             if(!visualType.type) visualType.type = defaultCategory;
 
@@ -132,7 +132,7 @@ define([
     }
 
     function buildVisualTypeId(localTypeId) {
-        return localTypeId ? (pluginJsId + '/' + localTypeId) : pluginJsId;
+        return localTypeId ? ('x-' + pluginJsId + '/' + localTypeId) : pluginJsId;
     }
 
     function registerMsgBundle(bundleId, relativePath) {

--- a/package-res/resources/web/visualApiConfig.js
+++ b/package-res/resources/web/visualApiConfig.js
@@ -22,13 +22,13 @@ define(function() {
 
       // Disable sunburst in Analyzer, by default, as it has been superseded by "ccc-sunburst".
       {
-        id:        "twelveDaysViz/sunBurst",
+        id:        "x-twelveDaysViz/sunBurst",
         container: "analyzer",
         enabled:   false
       },
 
       {
-        id:        /^twelveDaysViz\//,
+        id:        /^x-twelveDaysViz\//,
         container: "analyzer",
 
         getEditorProperties: function(editorDoc, filterPropsList, filterPropsMap) {


### PR DESCRIPTION
NOTE: This PR should only be accepted if the pentaho/pentaho-platform-plugin-common-ui#450 is accepted.

* Changed vizs to have its id prefixed with "x-" and its name prefixed with "X - ".
* fixed tooltip "arrow" option change to "arrowVisible"
* fixed TagCloud strange hover over behaviour

@pamval please review.